### PR TITLE
Overhaul UI for Clarity, Accessibility & Readability

### DIFF
--- a/about.html
+++ b/about.html
@@ -31,7 +31,8 @@
 		</ul>
 	</div>
 	<div id="main">
-		<div id="siteTitler">About Scroll Stop</div>
+		<h1>About Scroll Stop</h1>
+
 		<p>
 			Scroll Stop is a Google Chrome extension made by
 			<a id="indigoBox" href="http://www.indigobox.us" target="_blank">

--- a/about.html
+++ b/about.html
@@ -20,7 +20,7 @@
 	<div id="sideMenu">
 		<ul>
 			<li>
-				<a href="/options.html">Settings</a>
+				<a href="/settings.html">Settings</a>
 			</li>
 			<li class="active">
 				<a href="/about.html">About</a>

--- a/about.html
+++ b/about.html
@@ -18,22 +18,33 @@
 }(document, 'script', 'facebook-jssdk'));</script>
 	<div id="header"><img id="logo" src="images/icon48.png"><div id="headerText">Scroll Stop</div></div>
 	<div id="sideMenu">
-		<li>
-		<ul><a href="/options.html">Settings</a></ul>
-		<ul><a class="active" href="/about.html">About</a></ul>
-		<ul><a href="/help.html">Help</a></ul>
-		</li>
+		<ul>
+			<li>
+				<a href="/options.html">Settings</a>
+			</li>
+			<li class="active">
+				<a href="/about.html">About</a>
+			</li>
+			<li>
+				<a href="/help.html">Help</a>
+			</li>
+		</ul>
 	</div>
 	<div id="main">
-	<div id="siteTitler">About Scroll Stop</div>
-		<span id="about">Scroll Stop is a Google Chrome extension made by
-		<a id="indigoBox" href="http://www.indigobox.us" target="_blank">
-			<img src="images/indigoBoxFullLogoBlack.png" alt="indigoBox Studios" style="width:90px;margin-bottom:-5px;"></a>.</span>
-		<br>
-		<br>
-		Scroll Stop stores no information about you and has no ads. <br>
-		All of your app data is stored on your own computer, not ours.<br><br>
-		Like what we're doing? Share Scroll Stop with your friends, and like us on <a id="facebook" href="https://www.facebook.com/indigoBoxStudios/">Facebook</a>!<br><br>
+		<div id="siteTitler">About Scroll Stop</div>
+		<p>
+			Scroll Stop is a Google Chrome extension made by
+			<a id="indigoBox" href="http://www.indigobox.us" target="_blank">
+			<img src="images/indigoBoxFullLogoBlack.png" alt="indigoBox Studios" style="width:90px;margin-bottom:-5px;"></a>.
+		</p>
+		<p>
+			Scroll Stop stores no information about you and has no ads. <br>
+			All of your app data is stored on your own computer, not ours.
+		</p>
+		<p>
+			Like what we're doing? Share Scroll Stop with your friends, and like us on
+			<a id="facebook" href="https://www.facebook.com/indigoBoxStudios/">Facebook</a>!
+		</p>
 	</div>
   </body>
 </html>

--- a/css/main.css
+++ b/css/main.css
@@ -94,7 +94,8 @@ input[type="radio"] { margin-right: 10px; }
 	width: 100%;
 	height: 60px;
 	min-width: 860px;
-	background: #D2CFCF;
+	background: #fbfbfb;
+	box-shadow: 0px 2px 5px #bfbfbf;
 }
 #headerText
 {

--- a/css/main.css
+++ b/css/main.css
@@ -10,6 +10,20 @@ body
 	font-size: 16px;
 	margin: 0px;
 }
+h1, h2, h3, h4, h5, h6 {
+	font-weight: 600;
+}
+h1 {
+	color: red;
+	margin-bottom: 10px;
+}
+h2 {
+	color: #636363;
+	margin-bottom: 0;
+}
+p:first-of-type {
+	margin-top: 5px;
+}
 a
 {
 	text-decoration: none;
@@ -28,7 +42,7 @@ button {
 	cursor: pointer;
 	padding: 5px 15px;
 	color: #3c3737;
-	background-color: #F6F6F6;
+	background-color: #f0f0f0;
 	border: none;
 	border-radius: 5px;
 	font-weight: 600;
@@ -38,7 +52,7 @@ button {
 	transition: background 0.2s;
 }
 button:hover, button:focus {
-	background-color: #eae7e7;
+	background-color: #e3dede;
 }
 
 button.green {
@@ -90,6 +104,7 @@ input[type="radio"] { margin-right: 10px; }
 #header
 {
 	position: absolute;
+	top: 0;
 	z-index: 1;
 	width: 100%;
 	height: 60px;
@@ -175,6 +190,7 @@ input[type="radio"] { margin-right: 10px; }
 	border-radius: 100px;
 }
 .closeImage { width: 18px; }
+#add { margin-top: 5px; }
 #popupBody
 {
 	font-size: 100%;
@@ -267,7 +283,7 @@ input[type="radio"] { margin-right: 10px; }
 #buttons-bar
 {
 	position: relative;
-	margin-top: 25px;
+	margin-top: 35px;
 }
 #buttons-bar button {
 	font-size: 1rem;

--- a/css/main.css
+++ b/css/main.css
@@ -1,7 +1,12 @@
+/* Import Open Sans from Google Fonts */
+@import url('https://fonts.googleapis.com/css?family=Open+Sans');
+
+/* Make all elements use Open Sans by default */
+body, * { font-family: 'Open Sans', sans-serif; }
+
 body
 {
-	font-family: "Segoe UI", 'Product Sans', "Lucida Grande", Tahoma, sans-serif;
-	font-size: 100%;
+	font-size: 1em;
 	margin: 0px;
 }
 a
@@ -226,7 +231,10 @@ ul
 #buttons-bar
 {
 	position: relative;
-	margin-top: 5px;
+	margin-top: 25px;
+}
+#buttons-bar button {
+
 }
 .popActive {
 	color:Green;

--- a/css/main.css
+++ b/css/main.css
@@ -110,7 +110,8 @@ ul
 }
 .option-row
 {
-	position: relative;
+	display: flex;
+	align-items: center;
 	margin-top: 8px;
 	margin-bottom: 5px;
 }
@@ -121,13 +122,11 @@ ul
 }
 .closeImage
 {
-	cursor: pointer;
-	width: 19px;
-	left: 535px;
 	padding: 5px;
-	top: -3px;
-	position: absolute;
-    border-radius: 100px;
+	margin-left: 15px;
+	cursor: pointer;
+	width: 20px;
+	border-radius: 100px;
 	transition: background 0.2s;
 }
 .closeImage:hover
@@ -145,12 +144,12 @@ ul
 #popupTitle
 {
 	margin-top: 0px;
-    margin-bottom: 0px;
-    position: absolute;
-    top: 10px;
-    left: 70px;
-    font-size: 24px;
-    font-weight: normal;
+	margin-bottom: 0px;
+	position: absolute;
+	top: 10px;
+	left: 70px;
+	font-size: 24px;
+	font-weight: normal;
 }
 #popupLogo
 {

--- a/css/main.css
+++ b/css/main.css
@@ -1,59 +1,99 @@
 /* Import Open Sans from Google Fonts */
-@import url('https://fonts.googleapis.com/css?family=Open+Sans');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,600,700');
 
 /* Make all elements use Open Sans by default */
 body, * { font-family: 'Open Sans', sans-serif; }
 
 body
 {
-	font-size: 1em;
+	color: #262626;
+	font-size: 16px;
 	margin: 0px;
 }
 a
 {
-	color: black;
 	text-decoration: none;
 }
 input
 {
 	padding-left: 5px;
 }
-#sideMenu li
+select, input {
+	background: #fff;
+	border: solid 1px #b1afaf;
+	border-radius: 3px;
+	font-size: 1rem;
+}
+button {
+	cursor: pointer;
+	padding: 5px 15px;
+	color: #3c3737;
+	background-color: #F6F6F6;
+	border: none;
+	border-radius: 5px;
+	font-weight: 600;
+	text-align: center;
+	box-shadow: 0px 3px 4px #0000002e;
+	letter-spacing: 0.2px;
+	transition: background 0.2s;
+}
+button:hover, button:focus {
+	background-color: #eae7e7;
+}
+
+button.green {
+	color: #fff;
+	background-color: #008a00;
+}
+button.green:hover, button.green:focus {
+	background-color: #007000;
+}
+
+/* Space out a button following a button */
+button + button {
+	margin-left: 5px;
+}
+input[type="radio"] { margin-right: 10px; }
+#sideMenu ul
 {
+	margin: 0;
+	padding: 0;
 	position: relative;
 	top: 70px;
 	list-style: none;
-	font-weight: bolder;
+	font-weight: 600;
 	font-size: 20px;
+	padding-top: 10px;
 }
 #sideMenu a
 {
-	transition: color 0.2s;
+	display: block;
+	padding: 10px 40px;
+	color: #6b6b6b;
 }
-#sideMenu a:hover
-{
-	color: red;
+#sideMenu li {
+	transition: background-color 0.2s;
+	margin: 0;
 }
-#sideMenu a.active
+#sideMenu li:hover {
+	background-color: #c7c6c6;
+}
+#sideMenu li.active {
+	background-color: #717171;
+}
+#sideMenu li.active a
 {
 	cursor: default;
-	color: red;
+	color: white;
 	text-decoration: none !important;
-}
-ul
-{
-	margin-top: 5px;
-	margin-bottom: 0px;
 }
 #header
 {
 	position: absolute;
 	z-index: 1;
 	width: 100%;
-	color: black;
 	height: 60px;
 	min-width: 860px;
-	/* Old from indigoBox: background: linear-gradient(to bottom, #222222, #111111); */
 	background: #D2CFCF;
 }
 #headerText
@@ -83,7 +123,7 @@ ul
 	bottom: 0px;
 	width: 210px;
 	height: 100%;
-	background: linear-gradient(to right, white, rgb(228, 228, 228));
+	background: #e4e4e4;
 }
 #siteTitler
 {
@@ -125,22 +165,17 @@ ul
 	margin-left: 5px;
 	padding: 1px;
 }
-.closeImage
-{
-	padding: 5px;
+.close-btn {
+	background: none;
+	box-shadow: none;
+	display: flex;
 	margin-left: 15px;
-	cursor: pointer;
-	width: 20px;
+	padding: 8px;
 	border-radius: 100px;
-	transition: background 0.2s;
 }
-.closeImage:hover
-{
-	background: #D8D8D8;
-}
+.closeImage { width: 18px; }
 #popupBody
 {
-	font-family: "Segoe UI", "Open Sans", "Lucida Grande", Tahoma, sans-serif;
 	font-size: 100%;
 	width: 300px;
 	background: #FEFEFE;
@@ -182,8 +217,8 @@ ul
 	position: absolute;
 	height: 21px;
 	color: green;
-	top: 2px;
-	left: 160px;
+	top: 5px;
+	left: 300px;
 }
 #pause
 {
@@ -234,7 +269,7 @@ ul
 	margin-top: 25px;
 }
 #buttons-bar button {
-
+	font-size: 1rem;
 }
 .popActive {
 	color:Green;
@@ -296,15 +331,8 @@ margin-right: 10%;
 
 .button-limit {
 	color: #B80A0A;
-	text-align:center;
-	box-shadow: 0px 3px 4px #0000002e;
-	background-color: #F6F6F6;
-	border: none;
 	padding-top: 5px;
 	padding-bottom: 5px;
-	font-family: 'Segoe UI', 'Open Sans', sans-serif;
-	font-weight: 600;
-	letter-spacing: 0.2px;
 	padding-left: 15px;
 	padding-right: 15px;
 	margin-left: auto;

--- a/css/main.css
+++ b/css/main.css
@@ -142,10 +142,6 @@ ul
 	background: #FEFEFE;
 	height:250px;
 }
-#status
-{
-	margin-top: 3px;
-}
 #popupTitle
 {
 	margin-top: 0px;
@@ -197,15 +193,9 @@ ul
 }
 .popupText
 {
-	margin-left: 5px;
 	left:0px;
 	right:0px;
 	width:100%;
-
-}
-.popupText b
-{
-	/*margin-left: 5px;*/
 }
 #cog
 {
@@ -247,13 +237,13 @@ ul
 	letter-spacing: 1.3px;
 }
 #popupHeader {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	background-color:Green;
-	top:-3px;
-	left:-5px;
 	right:0px;
 	width:100%;
 	height:30px;
-	position: relative;
 	color:#FFF;
 	letter-spacing: 1px;
 	font-size:18px;

--- a/help.html
+++ b/help.html
@@ -11,28 +11,38 @@
 	<body>
 	<div id="header"><img id="logo" src="images/icon48.png"><div id="headerText">Scroll Stop</div></div>
 	<div id="sideMenu">
-		<li>
-		<ul><a  href="/options.html">Settings</a></ul>
-		<ul><a href="/about.html">About</a></ul>
-		<ul><a class="active" href="/help.html">Help</a></ul>
-		</li>
+		<ul>
+			<li>
+				<a  href="/options.html">Settings</a>
+			</li>
+			<li>
+				<a href="/about.html">About</a>
+			</li>
+			<li class="active">
+				<a href="/help.html">Help</a>
+			</li>
+		</ul>
 	</div>
 	<div id="main">
-	<div id="siteTitler">Help Getting Started</div>
-		To get started with Scroll Stop, open the options and enter a URL that <br>
-		you would like Scroll Stop to be active on. You do not need to enter an <br>
-		exact URL in these fields, Scroll Stop will check to see if the URL <br>
-		contains the string you entered. For instance, typing "facebook" in the <br>
-		URL field will match "www.facebook.com", as well as other URLs that <br>
-		contain "facebook" in them.<br><br>
-
-		Then, after you have chosen a URL or a match parameter, type in a value,<br>
-		in pixels, for how far you want Scroll Stop to let you scroll before <br>
-		stopping you.<br><br>
-
-		Finally, you can specify the behavior Scroll Stop should take when you <br>
-		reach your scroll limit. You can choose between closing the tab, removing <br>
-		the contents of the tab, or redirecting to a different url.
+		<div id="siteTitler">Help Getting Started</div>
+		<p>
+			To get started with Scroll Stop, open the options and enter a URL that <br>
+			you would like Scroll Stop to be active on. You do not need to enter an <br>
+			exact URL in these fields, Scroll Stop will check to see if the URL <br>
+			contains the string you entered. For instance, typing "facebook" in the <br>
+			URL field will match "www.facebook.com", as well as other URLs that <br>
+			contain "facebook" in them.
+		</p>
+		<p>
+			Then, after you have chosen a URL or a match parameter, type in a value,<br>
+			in pixels, for how far you want Scroll Stop to let you scroll before <br>
+			stopping you.
+		</p>
+		<p>
+			Finally, you can specify the behavior Scroll Stop should take when you <br>
+			reach your scroll limit. You can choose between closing the tab, removing <br>
+			the contents of the tab, or redirecting to a different url.
+		</p>
 	</div>
   </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -13,7 +13,7 @@
 	<div id="sideMenu">
 		<ul>
 			<li>
-				<a  href="/options.html">Settings</a>
+				<a  href="/settings.html">Settings</a>
 			</li>
 			<li>
 				<a href="/about.html">About</a>

--- a/help.html
+++ b/help.html
@@ -24,7 +24,8 @@
 		</ul>
 	</div>
 	<div id="main">
-		<div id="siteTitler">Help Getting Started</div>
+		<h1>Help Getting Started</h1>
+
 		<p>
 			To get started with Scroll Stop, open the options and enter a URL that <br>
 			you would like Scroll Stop to be active on. You do not need to enter an <br>

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -24,8 +24,8 @@ function addSite()
 function addSiteField(index)
 {
 	document.getElementById("sites").insertAdjacentHTML('beforeend', '<div class="option-row" id="row' + index
-	+ '">On <input class="siteURL" placeholder="example.com" id="siteURL' + index
-	+ '" type="text"></input> stop after <input class="pxNum" value="500" id="pxNum' + index
+	+ '"><span>On &nbsp;</span><input class="siteURL" placeholder="example.com" id="siteURL' + index
+	+ '" type="text"></input><span> &nbsp;stop after &nbsp;</span><input class="pxNum" value="500" id="pxNum' + index
 	+ '" type="number" min="0"></input><select class="limitType"><option value="pixels">pixels</option>'
 	+ '<option value="screens">screens</option></select><img class="closeImage" id="remove' + index
 	+ '" src="../images/cross.png"><br></div>');

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -24,11 +24,13 @@ function addSite()
 function addSiteField(index)
 {
 	document.getElementById("sites").insertAdjacentHTML('beforeend', '<div class="option-row" id="row' + index
-	+ '"><span>On &nbsp;</span><input class="siteURL" placeholder="example.com" id="siteURL' + index
-	+ '" type="text"></input><span> &nbsp;stop after &nbsp;</span><input class="pxNum" value="500" id="pxNum' + index
+	+ '"><span>On&nbsp;</span><input class="siteURL" placeholder="example.com" id="siteURL' + index
+	+ '" type="text"></input><span>&nbsp;stop after&nbsp;</span><input class="pxNum" value="500" id="pxNum' + index
 	+ '" type="number" min="0"></input><select class="limitType"><option value="pixels">pixels</option>'
-	+ '<option value="screens">screens</option></select><img class="closeImage" id="remove' + index
-	+ '" src="../images/cross.png"><br></div>');
+	+ '<option value="screens">screens</option></select>'
+	+ '<button class="close-btn"  id="remove' + index + '">'
+	  + '<img class="closeImage" src="../images/cross.png">'
+	+ '</button><br></div>');
 	document.getElementById("remove" + index).addEventListener("click", function(){removeSite(index)});
 }
 

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -92,14 +92,17 @@ function renderStatus(statusText)
   document.getElementById('status').innerHTML = statusText;
 }
 
+// Limit a site from the popup, given a URL
 function addSiteFromPopup(url)
 {
   var siteURLs = localStorage["siteURLs"];
   var sitePXs = localStorage["sitePxs"];
+
   currentDomain = url.split('/')[2]; // get everything after http[s]://, and before trailing '/'
-  console.log("Adding " + currentDomain);
+
   var siteURLList;
   var sitePXList;
+
   if(siteURLs == null)
   {
 		siteURLList = [];
@@ -107,7 +110,7 @@ function addSiteFromPopup(url)
 	}
   else {
     siteURLList = siteURLs.split(",");
-    sitePXList = siteURLs.split(",");
+    sitePXList = sitePXs.split(",");
   }
   siteURLList.push(currentDomain);
   sitePXList.push(500); // Default is 500 pixels, which is what is added if done via the button.
@@ -133,8 +136,6 @@ function removeSiteFromPopup(url) {
   // But '' is in everything, so this would always report active.
 	for(var i = 0; i < siteArray.length; i++)
 	{
-    console.log(siteArray[i]);
-    console.log(currentDomain);
 		if(currentDomain.indexOf(siteArray[i]) > -1)
 		{
 			siteArray.splice(i, 1);
@@ -269,7 +270,6 @@ document.addEventListener('DOMContentLoaded', function()
 	getCurrentTabUrl(function(url)
 	{
     var siteURLs = localStorage["siteURLs"];
-    console.log(localStorage["siteURLs"]);
 		if(siteURLs != null && siteBlocked(url))
 		{
 			renderStatus(blockedText(url));

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "Scroll Stop",
-  "options_page": "options.html",
+  "options_page": "settings.html",
   "description": "Stop scrolling too far, and stay focused on what's important",
   "version": "0.0.6",
 

--- a/options.html
+++ b/options.html
@@ -22,7 +22,9 @@
 		<div id="siteTitler">Sites To Limit</div>
 		<div id="sites">
 			<div class="option-row" id="row0">
-				On <input class="siteURL" id="siteURL0" placeholder="example.com" type="text"></input> stop after
+				<span>On&nbsp;</span>
+				<input class="siteURL" id="siteURL0" placeholder="example.com" type="text"></input>
+				<span>&nbsp;stop after&nbsp;</span>
 				<input class="pxNum" id="pxNum0" type="number" value ="5" min="0"></input><select class="limitType"><option value="pixels">pixels</option><option value="screens">screens</option></select><img class="closeImage" id="remove0" src="images/cross.png"><br>
 			</div>
 		</div>

--- a/options.html
+++ b/options.html
@@ -12,16 +12,23 @@
 	<body>
 	<div id="header"><img id="logo" src="images/icon48.png"><div id="headerText">Scroll Stop</div></div>
 	<div id="sideMenu">
-		<li>
-		<ul><a class="active" href="/options.html">Settings</a></ul>
-		<ul><a href="/about.html">About</a></ul>
-		<ul><a href="/help.html">Help</a></ul>
-		</li>
+		<ul>
+			<li class="active">
+				<a href="/options.html">Settings</a>
+			</li>
+			<li>
+				<a href="/about.html">About</a>
+			</li>
+			<li>
+				<a href="/help.html">Help</a>
+			</li>
+		</ul>
 	</div>
 	<div id="main">
 		<div id="siteTitler">Sites To Limit</div>
 
 		<div id="sites">
+			<!-- Make sure this matches the HTML in addSiteField() -->
 			<div class="option-row" id="row0">
 				<span>On&nbsp;</span>
 				<input class="siteURL" id="siteURL0" placeholder="example.com" type="text"></input>
@@ -31,7 +38,9 @@
 					<option value="pixels">pixels</option>
 					<option value="screens">screens</option>
 				</select>
-				<img class="closeImage" id="remove0" src="images/cross.png"><br>
+				<button class="close-btn" id="remove0">
+					<img class="closeImage" src="images/cross.png">
+				</button>
 			</div>
 		</div>
 		<button id="add">Add Site</button>
@@ -39,14 +48,16 @@
 		<br><br>
 
 		<div id="siteTitler">Action</div>
-		What should happen when you scroll too far? <br>
+		<p>
+			What should happen when you scroll too far?
+		</p>
 		<input type="radio" name="closeBehav" value="close" checked="checked">Close tab <br>
 		<input type="radio" name="closeBehav" value="remove">Make tab blank <br>
 		<input type="radio" name="closeBehav" value="alert">Print a reminder message<br>
 		<input type="radio" name="closeBehav" value="redirect">Go to <input id="redirectURL" placeholder="example.com" type="text"></input><br>
 
 		<div id="buttons-bar">
-			<button id="save">Save Settings</button>
+			<button id="save" class="green">Save Settings</button>
 			<button id="reset">Clear Settings</button>
 			<span id="checkmark" style="display: none">Saved &#x2714</span>
 		</div>

--- a/options.html
+++ b/options.html
@@ -20,26 +20,36 @@
 	</div>
 	<div id="main">
 		<div id="siteTitler">Sites To Limit</div>
+
 		<div id="sites">
 			<div class="option-row" id="row0">
 				<span>On&nbsp;</span>
 				<input class="siteURL" id="siteURL0" placeholder="example.com" type="text"></input>
 				<span>&nbsp;stop after&nbsp;</span>
-				<input class="pxNum" id="pxNum0" type="number" value ="5" min="0"></input><select class="limitType"><option value="pixels">pixels</option><option value="screens">screens</option></select><img class="closeImage" id="remove0" src="images/cross.png"><br>
+				<input class="pxNum" id="pxNum0" type="number" value ="5" min="0"></input>
+				<select class="limitType">
+					<option value="pixels">pixels</option>
+					<option value="screens">screens</option>
+				</select>
+				<img class="closeImage" id="remove0" src="images/cross.png"><br>
 			</div>
 		</div>
 		<button id="add">Add Site</button>
+
 		<br><br>
+
 		<div id="siteTitler">Action</div>
 		What should happen when you scroll too far? <br>
 		<input type="radio" name="closeBehav" value="close" checked="checked">Close tab <br>
 		<input type="radio" name="closeBehav" value="remove">Make tab blank <br>
 		<input type="radio" name="closeBehav" value="alert">Print a reminder message<br>
 		<input type="radio" name="closeBehav" value="redirect">Go to <input id="redirectURL" placeholder="example.com" type="text"></input><br>
+
 		<div id="buttons-bar">
-		<button id="save">Save</button>
-		<button id="reset">Restore default</button>
-		<span id="checkmark" style="display: none">Saved &#x2714</span></div>
+			<button id="save">Save Settings</button>
+			<button id="reset">Clear Settings</button>
+			<span id="checkmark" style="display: none">Saved &#x2714</span>
+		</div>
 	</div>
   </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -16,7 +16,7 @@
   </head>
   <body id="popupBody">
 	<div class="popupText" id="status"></div>
-	<a id="options" href="/options.html">
+	<a id="options" href="/settings.html">
 	<div id="options-cont">
     <i class="material-icons" style="font-size:20px">
       exit_to_app

--- a/settings.html
+++ b/settings.html
@@ -4,7 +4,7 @@
 
 <html>
   <head>
-    <title>Scroll Stop - Options</title>
+    <title>Scroll Stop - Settings</title>
 	<script type="text/javascript" src="javascript/options.js"></script>
 	<script src="javascript/jquery-1.11.2.min.js"></script>
 	<link rel="stylesheet" type="text/css" href="css/main.css">
@@ -14,7 +14,7 @@
 	<div id="sideMenu">
 		<ul>
 			<li class="active">
-				<a href="/options.html">Settings</a>
+				<a href="/settings.html">Settings</a>
 			</li>
 			<li>
 				<a href="/about.html">About</a>

--- a/settings.html
+++ b/settings.html
@@ -25,7 +25,9 @@
 		</ul>
 	</div>
 	<div id="main">
-		<div id="siteTitler">Sites To Limit</div>
+		<h1>Settings</h1>
+
+		<h2>Sites To Limit</h2>
 
 		<div id="sites">
 			<!-- Make sure this matches the HTML in addSiteField() -->
@@ -45,9 +47,7 @@
 		</div>
 		<button id="add">Add Site</button>
 
-		<br><br>
-
-		<div id="siteTitler">Action</div>
+		<h2>Action</h2>
 		<p>
 			What should happen when you scroll too far?
 		</p>


### PR DESCRIPTION
## Description

This started out as a place for me to do some quick UI updates (see the title), but this turned into a lot of improvements. There's a lot of them, but I'll try and list them out as best I can:

- Accessibility: Made close image a button
- Accessibility: Made all pages use proper headings (`<h1>`, `<h2>`) and paragraphs (`<p>`)
- UI: Added Open Sans import and moved the whole UI to Open Sans to improve consistency and style
- UI: Overhauled the Settings page, including making the save button more highlighted and overriding default input styles
- UI: Overhauled sidebar and header to make it easier to tell what page you are on and to be a little nicer looking
- Tech Debt: Renamed `options.html` to `settings.html` to make sense with what we show in the UI

**Assignee Note:** I am assigning myself to this PR with the intention that I will deploy Scroll Stop after it is merged. The code was already tagged at version `0.0.6` and the current prod `0.0.5`, so despite the major changes I won't bump the version an extra number since we never actually released.

## Screenshots

Here's a comparison of the settings page with the same settings (click to expand):

| Before | After |
| --- | --- |
| ![chrome-extension___hjaclffbikdneicnleajghmppjdnnohl_options html](https://user-images.githubusercontent.com/3187531/52191035-32e18280-2808-11e9-9b53-b2df07b31f0d.png) | ![chrome-extension___dacbcjlamhcbdcjpphffmmbahbdaffjb_settings html](https://user-images.githubusercontent.com/3187531/52190863-155fe900-2807-11e9-9b43-003849c3fd6e.png) |


